### PR TITLE
ensure make_content_hash can accept a nil request body

### DIFF
--- a/lib/akamai/edgegrid.rb
+++ b/lib/akamai/edgegrid.rb
@@ -104,7 +104,7 @@ module Akamai #:nodoc:
 
       # Returns a hash of the HTTP POST body
       def make_content_hash(request) 
-        if request.method == 'POST' and request.body_exist? and request.body.length > 0
+        if request.method == 'POST' and request.body and request.body.length > 0
           body = request.body
           if body.length > @max_body
             @log.debug("data length #{body.length} is larger than maximum #{@max_body}")

--- a/test/testdata.json
+++ b/test/testdata.json
@@ -79,6 +79,18 @@
             "expectedAuthorization": "EG1-HMAC-SHA256 client_token=akab-client-token-xxx-xxxxxxxxxxxxxxxx;access_token=akab-access-token-xxx-xxxxxxxxxxxxxxxx;timestamp=20140321T19:34:21+0000;nonce=nonce-xx-xxxx-xxxx-xxxx-xxxxxxxxxxxx;signature=1gEDxeQGD5GovIkJJGcBaKnZ+VaPtrc4qBUHixjsPCQ="
         },
         {
+            "testName": "POST nil body",
+            "request": {
+                "method": "POST",
+                "path": "/testapi/v1/t6",
+                "data": null,
+                "headers": [
+                    {"Host": "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net"}
+                ]
+            },
+            "expectedAuthorization": "EG1-HMAC-SHA256 client_token=akab-client-token-xxx-xxxxxxxxxxxxxxxx;access_token=akab-access-token-xxx-xxxxxxxxxxxxxxxx;timestamp=20140321T19:34:21+0000;nonce=nonce-xx-xxxx-xxxx-xxxx-xxxxxxxxxxxx;signature=1gEDxeQGD5GovIkJJGcBaKnZ+VaPtrc4qBUHixjsPCQ="
+        },
+        {
             "testName": "Simple header signing with GET",
             "request": {
                 "method": "GET",


### PR DESCRIPTION
It appears that #body_exist? returns true when request.body is nil.
