### PR TITLE
dxissue 58 license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,27 @@
 1.0.6
 -----
-* fix bug with sections on edgerc (thanks Kirsten)
+* Fix bug with sections on `edgerc` (thanks Kirsten).
 
 1.0.5
 -----
-* add edgerc support (thanks Kirsten)
+* Add `edgerc` support (thanks Kirsten).
 
 1.0.4
 -----
-* fix bug with nil request.body
+* Fix bug with the nil `request.body`.
 
 1.0.3
 -----
-* support QA environment
+* Support the QA environment.
 
 1.0.2
 -----
-* Update link to developer site
+* Update link to the developer site.
 
 1.0.1
 -----
-* Change POST behavior to truncate and max_body to 128kb (GRID-236)
+* Change the `POST` behavior to truncate and `max_body` to `128kb` (GRID-236).
 
 1.0
 ---
-* Initial release
+* Initial release.

--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@ recommend that a file or class name and description of purpose be included on
 the same "printed page" as the copyright notice for easier identification within
 third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 Akamai Technologies, Inc. All rights reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -179,7 +179,7 @@ third-party archives.
    Copyright 2024 Akamai Technologies, Inc. All rights reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
+   you may not use these files except in compliance with the License.
    You may obtain a copy of the License at
 
      http://www.apache.org/licenses/LICENSE-2.0

--- a/README.md
+++ b/README.md
@@ -210,6 +210,6 @@ To report an issue or make a suggestion, create a new [GitHub issue](https://git
 
 Copyright 2024 Akamai Technologies, Inc. All rights reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use these files except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/lib/akamai/edgegrid.rb
+++ b/lib/akamai/edgegrid.rb
@@ -1,24 +1,3 @@
-#
-# = akamai/edgegrid.rb
-#
-# For more information visit https://developer.akamai.com
-#
-# == License
-#
-#   Copyright 2024 Akamai Technologies, Inc. All rights reserved.
-#
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
-
 require 'openssl'
 require 'base64'
 require 'logger'

--- a/lib/akamai/edgegrid.rb
+++ b/lib/akamai/edgegrid.rb
@@ -39,7 +39,7 @@ module Akamai #:nodoc:
     #         :access_token => 'aaaaaaaaaaaaaa'
     #      )
     #   >> request = Net::HTTP::Get.new URI.join(
-    #         baseuri.to_s, '/diagnostic-tools/v1/locations'
+    #         baseuri.to_s, '/identity-management/v3/user-profile'
     #      ).to_s
     #   >> response = http.request(request)
     #   >> puts JSON.parse(response.body)['locations'][0]

--- a/test/test_edgegrid.rb
+++ b/test/test_edgegrid.rb
@@ -1,21 +1,3 @@
-#!/usr/bin/env ruby
-#
-# For more information visit https://developer.akamai.com
-#
-#   Copyright 2024 Akamai Technologies, Inc.  All rights reserved.
-#
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
-
 if ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.start do

--- a/test/test_edgerc.rb
+++ b/test/test_edgerc.rb
@@ -1,21 +1,3 @@
-#!/usr/bin/env ruby
-#
-# For more information visit https://developer.akamai.com
-#
-#   Copyright 2024 Akamai Technologies, Inc.  All rights reserved.
-#
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
-
 if ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.start do


### PR DESCRIPTION
@jjjhhhlll  This is to add minor updates, including:

- Add specific copyright information to the LICENSE file.
- Remove the comment part from the code files, as the copyright information on the main readme already includes the current date and covers any file in that repo not marked with a separate date. This is also to avoid remembering to update the date on each code file regularly (This will need to be done only on README and LICENSE files).